### PR TITLE
chore: Rename NavBar to PrimaryNavBar component

### DIFF
--- a/citizen-ui/src/components/PrimaryNavBar.jsx
+++ b/citizen-ui/src/components/PrimaryNavBar.jsx
@@ -4,7 +4,7 @@ import { TfiList } from "react-icons/tfi";
 import { FaRegBell } from "react-icons/fa";
 import { FaRegUser } from "react-icons/fa6";
 
-function NavBar() {
+function PrimaryNavBar() {
   const items = [
     { label: "Home", Icon: IoHomeOutline },
     { label: "Requests", Icon: TfiList },
@@ -28,4 +28,4 @@ function NavBar() {
   );
 }
 
-export default NavBar;
+export default PrimaryNavBar;

--- a/citizen-ui/src/pages/Home.jsx
+++ b/citizen-ui/src/pages/Home.jsx
@@ -1,9 +1,9 @@
-import NavBar from "../components/NavBar";
+import PrimaryNavBar from "../components/PrimaryNavBar";
 
 const Home = () => {
   return (
     <div className="relative flex h-full flex-col items-center justify-center bg-gradient-to-t from-[#3A66A3] from-4% via-[#9DB2D1] via-72% to-[#FFFFFF] to-100%">
-      <NavBar />
+      <PrimaryNavBar />
     </div>
   );
 };


### PR DESCRIPTION
Renamed NavBar.jsx to PrimaryNavBar.jsx and updated references in Home.jsx to use the new component name. This improves clarity and consistency in component naming.