### PR TITLE
feat: Move PrimaryNavBar to Home page and update navigation

### DIFF
--- a/citizen-ui/src/components/PrimaryNavBar.jsx
+++ b/citizen-ui/src/components/PrimaryNavBar.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import { IoHomeOutline } from "react-icons/io5";
 import { TfiList } from "react-icons/tfi";
 import { FaRegBell } from "react-icons/fa";
@@ -8,7 +9,7 @@ function PrimaryNavBar() {
   const [active, setActive] = useState(0);
 
   const items = [
-    { label: "Home", Icon: IoHomeOutline },
+    { path: "/", label: "Home", Icon: IoHomeOutline },
     { label: "Requests", Icon: TfiList },
     { label: "Notifications", Icon: FaRegBell },
     { label: "Account", Icon: FaRegUser },
@@ -21,10 +22,11 @@ function PrimaryNavBar() {
           className="pointer-events-none absolute inset-y-1 w-1/4 rounded-full bg-white/15 shadow-[inset_0_1px_0_rgba(255,255,255,.55),0_8px_32px_rgba(0,0,0,.25)] ring-1 ring-white/40 transition-transform duration-300 ease-out"
           style={{ transform: `translateX(${active * 100}%)` }}
         />
-        {items.map(({ label, Icon }, index) => {
+        {items.map(({ label, Icon, path }, index) => {
           const isActive = index === active;
           return (
-            <div
+            <Link
+              to={path}
               key={label}
               type="button"
               onClick={() => setActive(index)}
@@ -42,7 +44,7 @@ function PrimaryNavBar() {
               >
                 {label}
               </span>
-            </div>
+            </Link>
           );
         })}
       </div>

--- a/citizen-ui/src/pages/Home.jsx
+++ b/citizen-ui/src/pages/Home.jsx
@@ -1,9 +1,11 @@
 import HomePage from "./HomePage";
+import PrimaryNavBar from "../components/PrimaryNavBar";
 
 export default function Home() {
   return (
     <div className="relative flex h-screen flex-col bg-gradient-to-t from-[#3A66A3] from-4% via-[#9DB2D1] via-72% to-[#FFFFFF] to-100%">
       <HomePage />
+      <PrimaryNavBar />
     </div>
   );
 }

--- a/citizen-ui/src/pages/HomePage.jsx
+++ b/citizen-ui/src/pages/HomePage.jsx
@@ -1,14 +1,11 @@
 import { Link } from "react-router-dom";
-import PrimaryNavBar from "../components/PrimaryNavBar";
 
 const Home = () => {
   return (
-    <div >
+    <div>
       <div className="flex-1 overflow-y-auto pb-20">
-        {" "}
         <h1 className="mt-6 mb-6 text-left text-4xl font-extrabold">Home</h1>
         <div className="mt-6 mb-6 grid grid-cols-2 gap-4 px-4">
-          {" "}
           <Link
             to="/travel-warrant"
             className="cursor-pointer rounded-xl border border-white/30 bg-white/20 p-4 text-center shadow-lg backdrop-blur-md transition duration-300 hover:bg-white/30"
@@ -22,8 +19,9 @@ const Home = () => {
             </div>
             <p className="text-lg font-medium md:text-xl">
               Request a Travel Warrant
-            </p>{" "}
+            </p>
           </Link>
+
           <Link
             to="/salary-particular"
             className="cursor-pointer rounded-xl border border-white/30 bg-white/20 p-4 text-center shadow-lg backdrop-blur-md transition duration-300 hover:bg-white/30"
@@ -36,14 +34,12 @@ const Home = () => {
               />
             </div>
             <p className="text-lg font-medium md:text-xl">
-              {" "}
               Request a Salary Particular Confirmation
             </p>
           </Link>
         </div>
         <h2 className="mb-5 px-4 text-xl font-bold">Recent</h2>{" "}
         <div className="mx-4 mb-6 flex items-center justify-between rounded-xl border border-white/30 bg-white/20 p-4 backdrop-blur-md">
-          {" "}
           <div className="flex items-center gap-3">
             <div>
               <img
@@ -62,8 +58,6 @@ const Home = () => {
           </button>
         </div>
       </div>
-
-      <PrimaryNavBar />
     </div>
   );
 };


### PR DESCRIPTION
PrimaryNavBar is now rendered in Home.jsx instead of HomePage.jsx for better layout control. Navigation items in PrimaryNavBar use react-router Link for routing, and the HomePage component is cleaned up to remove redundant code.