### PR TITLE
update logic

### DIFF
--- a/server/Controllers/WarrentController.py
+++ b/server/Controllers/WarrentController.py
@@ -351,23 +351,42 @@ async def get_Warrents_logic() -> list:
         )
 
 
+async def _require_employee_role(employee_id: str, required_role: str) -> dict:
+    """Validate that employee_id exists in employees_collection and has the required role."""
+    try:
+        emp = await employees_collection.find_one({"_id": ObjectId(employee_id)})
+    except Exception:
+        raise HTTPException(
+            status_code=400, detail="Invalid employee/handler id format"
+        )
+
+    if not emp:
+        raise HTTPException(status_code=404, detail="Employee not found")
+
+    role = (emp.get("role") or "").upper()
+    if role != required_role.upper():
+        raise HTTPException(
+            status_code=403,
+            detail=f"Only {required_role.upper()} can access this resource",
+        )
+    return emp
+
+
 async def get_requests_for_gs(gs_handler_id: str) -> List[dict]:
     """
     Return only the warrant documents related to a GS (by handler_id).
-    Matches requests where:
-      - current_handler_id == gs_handler_id, or
-      - handler_history contains handler_id == gs_handler_id
-    Uses request.resource_name == 'warrent' and request.resource_id to fetch warrants.
     """
+    # Enforce role: must be GS
+    await _require_employee_role(gs_handler_id, "GS")
+
     try:
         query = {
-            "resource_name": "warrent",  # use resource_name (request_type may not exist)
+            "resource_name": "warrent",
             "$or": [
                 {"current_handler_id": gs_handler_id},
                 {"handler_history": {"$elemMatch": {"handler_id": gs_handler_id}}},
             ],
         }
-
         results: List[dict] = []
         seen: Set[str] = set()
         cursor = requests_collection.find(query)
@@ -386,7 +405,6 @@ async def get_requests_for_gs(gs_handler_id: str) -> List[dict]:
             if not warr:
                 continue
 
-            # sanitize for JSON
             warr["_id"] = str(warr["_id"])
             for dt_field in (
                 "TravelDate",
@@ -407,7 +425,6 @@ async def get_requests_for_gs(gs_handler_id: str) -> List[dict]:
             results.append(warr)
 
         return results
-
     except Exception as e:
         raise HTTPException(
             status_code=500, detail=f"Error fetching GS warrants: {str(e)}"
@@ -417,11 +434,10 @@ async def get_requests_for_gs(gs_handler_id: str) -> List[dict]:
 async def get_requests_for_ds(ds_handler_id: str) -> List[dict]:
     """
     Return only the warrant documents related to a DS (by handler_id).
-    Matches requests where:
-      - current_handler_id == ds_handler_id, or
-      - handler_history contains handler_id == ds_handler_id
-    Uses request.resource_name == 'warrent' and request.resource_id to fetch warrants.
     """
+    # Enforce role: must be DS
+    await _require_employee_role(ds_handler_id, "DS")
+
     try:
         query = {
             "resource_name": "warrent",
@@ -430,7 +446,6 @@ async def get_requests_for_ds(ds_handler_id: str) -> List[dict]:
                 {"handler_history": {"$elemMatch": {"handler_id": ds_handler_id}}},
             ],
         }
-
         results: List[dict] = []
         seen: Set[str] = set()
         cursor = requests_collection.find(query)
@@ -449,7 +464,6 @@ async def get_requests_for_ds(ds_handler_id: str) -> List[dict]:
             if not warr:
                 continue
 
-            # sanitize for JSON
             warr["_id"] = str(warr["_id"])
             for dt_field in (
                 "TravelDate",
@@ -470,7 +484,6 @@ async def get_requests_for_ds(ds_handler_id: str) -> List[dict]:
             results.append(warr)
 
         return results
-
     except Exception as e:
         raise HTTPException(
             status_code=500, detail=f"Error fetching DS warrants: {str(e)}"


### PR DESCRIPTION
This pull request adds role-based access control to the warrant retrieval endpoints by introducing a helper function to validate employee roles before fetching warrant requests. Now, only employees with the appropriate role (GS or DS) can access the corresponding warrant data. The changes also include some minor code cleanup.

**Role-based access control:**

* Added a new helper function `_require_employee_role` to check if an employee exists and has the required role before allowing access to warrant data.
* Updated `get_requests_for_gs` to require the requesting employee to have the "GS" role before proceeding.
* Updated `get_requests_for_ds` to require the requesting employee to have the "DS" role before proceeding.

**Code cleanup:**

* Removed unnecessary comments and blank lines in both warrant retrieval functions for improved readability. [[1]](diffhunk://#diff-3ef856986004da26f6d8fda23c9ed946b56fd95fb0439fb4458e026c88e07212L388) [[2]](diffhunk://#diff-3ef856986004da26f6d8fda23c9ed946b56fd95fb0439fb4458e026c88e07212L409) [[3]](diffhunk://#diff-3ef856986004da26f6d8fda23c9ed946b56fd95fb0439fb4458e026c88e07212L432) [[4]](diffhunk://#diff-3ef856986004da26f6d8fda23c9ed946b56fd95fb0439fb4458e026c88e07212L451) [[5]](diffhunk://#diff-3ef856986004da26f6d8fda23c9ed946b56fd95fb0439fb4458e026c88e07212L472